### PR TITLE
Fix document finders

### DIFF
--- a/lib/web_merge/document.rb
+++ b/lib/web_merge/document.rb
@@ -21,8 +21,8 @@ module WebMerge
       @size_height = options[:size_height]
     end
 
-    def self.find(doc_id)
-      instance = empty_instance
+    def self.find(doc_id, client: required(:client))
+      instance = empty_instance(client)
       instance.send(:id=, doc_id)
       instance.reload
     end
@@ -33,9 +33,9 @@ module WebMerge
       end
     end
 
-    def self.all
-      @client.get_documents.map do |doc_hash|
-        instance = empty_instance
+    def self.all(client: required(:client))
+      client.get_documents.map do |doc_hash|
+        instance = empty_instance(client)
         instance.send(:update_instance, doc_hash)
         instance
       end
@@ -112,8 +112,8 @@ module WebMerge
     private
     attr_writer :id, :key, :size, :active, :url
 
-    def self.empty_instance
-      new(name: "", type: "", output: "")
+    def self.empty_instance(client)
+      new(client: client, name: "", type: "", output: "")
     end
 
     def update_instance(response)

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require_relative '../lib/web_merge/constants'
+require_relative '../lib/web_merge/document'
+
+describe WebMerge::Document do
+  describe '.find' do
+    let(:document) do
+      described_class.new(client: 'foo', name: 'foo', type: 'foo').tap do |document|
+        document.send(:id=, rand(1..10))
+      end
+    end
+    let(:client) { double(:client, get_document: response ) }
+    let(:response) { { foo: 'irrelevant' } }
+
+    it 'returns a document' do
+      finder = described_class.find(document.id, client: client)
+      expect(finder).to be_kind_of(described_class)
+    end
+  end
+
+  describe '.all' do
+    let(:client) { double(:client, get_documents: response ) }
+    let(:response) { [ first_document: 'foo', second_document: 'bar' ] }
+
+    it 'returns a collection of documents' do
+      finder = described_class.all(client: client)
+
+      finder.each do |doc|
+        expect(doc).to be_kind_of(described_class)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'active_model'
+require 'rspec'

--- a/web_merge.gemspec
+++ b/web_merge.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "activemodel", ">= 3.0"
 end

--- a/web_merge.gemspec
+++ b/web_merge.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
+  spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "activemodel", ">= 3.0"
 end


### PR DESCRIPTION
The finders inside of the `Document` class don't currently work without passing in an api client.

I've fixed `.all` and `.find` and added tests.

I suggest that `.each` gets removed or deprecated. The all method that it calls just flat out returns a nil and doesn't even refer to the all method defined on the `Document` class. But that's your call.