### PR TITLE
Raise Document errors over Runtime errors

### DIFF
--- a/lib/web_merge/document.rb
+++ b/lib/web_merge/document.rb
@@ -59,18 +59,18 @@ module WebMerge
       else
         @client.update_document(id, as_form_data)
       end
-      raise WebMerge::DocumentError.new(response['error']) if response['error'].present?
+      raise_error(response['error']) if response['error'].present?
 
       update_instance(response.symbolize_keys)
       true
     end
 
     def save!
-      raise "Document contains errors: #{errors.full_messages.join(", ")}" unless save
+      raise_error("Document contains errors: #{errors.full_messages.join(", ")}") unless save
     end
 
     def reload
-      raise "Cannot reload a new document, perhaps you'd like to call `save' first?" if new_document?
+      raise_error("Cannot reload a new document, perhaps you'd like to call `save' first?") if new_document?
       response = @client.get_document(id)
       update_instance(response)
       self
@@ -83,7 +83,7 @@ module WebMerge
     end
 
     def fields
-      raise "Cannot fetch fields for an unpersisted document, perhaps you'd like to call `save' first?" if new_document?
+      raise_error("Cannot fetch fields for an unpersisted document, perhaps you'd like to call `save' first?")if new_document?
       @fields ||= @client.get_document_fields(id)
     end
 
@@ -92,7 +92,7 @@ module WebMerge
     end
 
     def merge(field_mappings, options = {}, &block)
-      raise "Cannot merge an unpersisted document, perhaps you'd like to call `save' first?" if new_document?
+      raise_error("Cannot merge an unpersisted document, perhaps you'd like to call `save' first?") if new_document?
       @client.merge_document(id, key, field_mappings, options, &block)
     end
 
@@ -144,5 +144,8 @@ module WebMerge
       end
     end
 
+    def raise_error(message)
+      raise WebMerge::DocumentError.new(message)
+    end
   end
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -108,5 +108,17 @@ describe WebMerge::Document do
         expect { document_with_merge_field_errors.save! }.to raise_error(WebMerge::DocumentError)
       end
     end
+
+    context 'document is invalid' do
+      let(:document) do
+        described_class.new(client: client, name: 'foo', type: 'docx')
+      end
+      let(:response) { 'N/A' }
+
+      it 'raises an error upon document save error' do
+        expect(document).to receive(:valid?).and_return(false)
+        expect { document.save! }.to raise_error(WebMerge::DocumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
1. I added some test coverage.
2. Whenever a document method fails, it raises a more expressive `DocumentError`.

We've been using this in production for almost 2 years.