### PR TITLE
Switch usage of obsolete method URI.escape to URI.encode_www_form

### DIFF
--- a/lib/web_merge/api.rb
+++ b/lib/web_merge/api.rb
@@ -64,7 +64,7 @@ module WebMerge
     def merge_document(doc_id, doc_key, field_mappings, options = {}, &block)
       query = ""
       if options.present?
-        query = "?" + URI.encode(options.map{|k,v| "#{k}=#{v}"}.join("&"))
+        query = "?" + URI.encode_www_form(options)
       end
       post("#{WebMerge::Constants::MERGE_ENDPOINT}/#{doc_id}/#{doc_key}#{query}", field_mappings, &block)
     end


### PR DESCRIPTION
This PR removes the usage of `URI.escape`, and instead uses `URI.encode_www_form`

Usage of `URI.escape` generates the follow warnings
`.gem/ruby/2.7.1/gems/web_merge-1.0.3/lib/web_merge/api.rb:59: warning: URI.escape is obsolete`

This method [has been obsolete for over 12 years](https://github.com/ruby/ruby/commit/238b979f1789f95262a267d8df6239806f2859cc). More recent versions of ruby however are warning about it even when not in verbose mode, which previous masked it.

As far as I am aware the usage of `URI.escape` in this repository should be perfectly served by `URI.encode_www_form`.